### PR TITLE
Several cleanups to coverage and CI settings

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+branch=True
+source=wsproto
+omit=
+  setup.py
+
+[report]
+exclude_lines =
+  pragma: no cover
+  ^def test_
+precision = 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - "pip install -r test_requirements.txt"
   - "pip install flake8"
   - "pip install sphinx"
+  - "pip install codecov"
 before_script:
   - "flake8 --max-complexity 10 wsproto"
   - "sphinx-build -nW -b html -d docs/build/doctrees docs/source docs/build/html"

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -3,9 +3,10 @@
 set -e
 set -x
 
-if [[ $TRAVIS_PYTHON_VERSION == pypy ]]; then
-    py.test test/
-else
-    coverage run -m py.test test/
-    coverage report
-fi
+mkdir empty
+cd empty
+
+INSTALLDIR=$(python -c "import os, wsproto; print(os.path.dirname(wsproto.__file__))")
+pytest --cov=$INSTALLDIR --cov-config=../.coveragerc ../test/
+
+codecov

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-pytest==3.0.1
-pytest-cov==2.3.1
+pytest==3.0.4
+pytest-cov==2.4.0
 coverage==4.2
 pytest-xdist==1.15.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,3 @@
 pytest==3.0.4
 pytest-cov==2.4.0
 coverage==4.2
-pytest-xdist==1.15.0

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27, py35, lint, docs
 
 [testenv]
 deps = -r{toxinidir}/test_requirements.txt
-commands = pytest -n 4 --cov wsproto {toxinidir}/test/
+commands = pytest --cov {envsitepackagesdir}/wsproto --cov-config {toxinidir}/.coveragerc {toxinidir}/test/
 
 [testenv:lint]
 basepython = python3.5


### PR DESCRIPTION
- Enable branch coverage
- Restrict coverage to wsproto, not random other libraries it uses
- Fix tox.ini's --cov argument so coverage works
- Enable codecov reporting
- A few other misc updates

You may need to go to https://codecov.io to turn on Codecov reporting
for this repository. Once you've done this, it'll gather up coverage
reports from Travis-CI runs, merge the different runs together, and
generate nice reports like this:

   https://codecov.io/gh/njsmith/wsproto/tree/better-testing-and-coverage/wsproto