### PR TITLE
Use os.urandom to choose masking key

### DIFF
--- a/wsproto/connection.py
+++ b/wsproto/connection.py
@@ -9,7 +9,6 @@ An implementation of a WebSocket connection.
 import os
 import base64
 import hashlib
-import random
 
 from enum import Enum
 

--- a/wsproto/connection.py
+++ b/wsproto/connection.py
@@ -6,6 +6,7 @@ wsproto/connection
 An implementation of a WebSocket connection.
 """
 
+import os
 import base64
 import hashlib
 import random
@@ -242,8 +243,9 @@ class WSConnection(object):
                 yield BytesReceived(payload, fin)
 
     def _generate_nonce(self):
-        nonce = bytes(random.getrandbits(8) for x in range(0, 16))
-        self._nonce = base64.b64encode(nonce)
+        # os.urandom may be overkill for this use case, but I don't think this
+        # is a bottleneck, and better safe than sorry...
+        self._nonce = base64.b64encode(os.urandom(16))
 
     def _generate_accept_token(self, token):
         accept_token = token + ACCEPT_GUID

--- a/wsproto/frame_protocol.py
+++ b/wsproto/frame_protocol.py
@@ -9,7 +9,6 @@ WebSocket frame protocol implementation.
 import os
 import codecs
 import itertools
-import random
 import struct
 
 from enum import Enum, IntEnum

--- a/wsproto/frame_protocol.py
+++ b/wsproto/frame_protocol.py
@@ -6,6 +6,7 @@ wsproto/frame_protocol
 WebSocket frame protocol implementation.
 """
 
+import os
 import codecs
 import itertools
 import random
@@ -59,10 +60,6 @@ LOCAL_ONLY_CLOSE_REASONS = (
     CloseReason.ABNORMAL_CLOSURE,
     CloseReason.TLS_HANDHSAKE_FAILED,
 )
-
-
-def random_byte():
-    return random.getrandbits(8)
 
 
 class FrameProtocol(object):
@@ -434,7 +431,18 @@ class FrameProtocol(object):
                 header += struct.pack('!H', second_payload)
 
         if self.client:
-            masking_key = bytes(random_byte() for x in range(0, 4))
+            # "The masking key is a 32-bit value chosen at random by the
+            # client.  When preparing a masked frame, the client MUST pick a
+            # fresh masking key from the set of allowed 32-bit values.  The
+            # masking key needs to be unpredictable; thus, the masking key
+            # MUST be derived from a strong source of entropy, and the masking
+            # key for a given frame MUST NOT make it simple for a server/proxy
+            # to predict the masking key for a subsequent frame.  The
+            # unpredictability of the masking key is essential to prevent
+            # authors of malicious applications from selecting the bytes that
+            # appear on the wire."
+            #   -- https://tools.ietf.org/html/rfc6455#section-5.3
+            masking_key = os.urandom(4)
             maskbytes = itertools.cycle(masking_key)
             return header + masking_key + \
                 bytes(b ^ next(maskbytes) for b in payload)


### PR DESCRIPTION
Quoth RFC 6455:

   The masking key is a 32-bit value chosen at random by the client.
   When preparing a masked frame, the client MUST pick a fresh masking
   key from the set of allowed 32-bit values.  The masking key needs to
   be unpredictable; thus, the masking key MUST be derived from a strong
   source of entropy, and the masking key for a given frame MUST NOT
   make it simple for a server/proxy to predict the masking key for a
   subsequent frame.  The unpredictability of the masking key is
   essential to prevent authors of malicious applications from selecting
   the bytes that appear on the wire.