### PR TITLE
Better handshake header parsing

### DIFF
--- a/wsproto/events.py
+++ b/wsproto/events.py
@@ -8,7 +8,8 @@ Events that result from processing data on a WebSocket connection.
 
 
 class ConnectionRequested(object):
-    def __init__(self, h11request):
+    def __init__(self, proposed_subprotocols, h11request):
+        self.proposed_subprotocols = proposed_subprotocols
         self.h11request = h11request
 
     def __repr__(self):


### PR DESCRIPTION
- HTTP headers can occur multiple times; previous code was blindly
  converting to dict and could silently discard parts of the
  handshake.

- Several RFC-required checks were missing. (There's still some work
  to do here, but it's better.)

- Expose the client's list of proposed subprotocols to the server as
  part of the ConnectionRequested event, and let the server pick one.