### PR TITLE
Client should only send Sec-WebSocket-Protocol if non-empty

### DIFF
--- a/test/test_upgrade.py
+++ b/test/test_upgrade.py
@@ -57,6 +57,10 @@ class TestClientUpgrade(object):
         assert 'sec-websocket-version' in headers
         assert headers['sec-websocket-protocol'] == 'foo, bar'
 
+    def test_no_subprotocols(self):
+        ws, method, path, version, headers = self.initiate("foo", "/bar")
+        assert 'sec-websocket-protocol' not in headers
+
     def test_correct_accept_token(self):
         _host = 'frob.nitz'
         _path = '/fnord'

--- a/wsproto/connection.py
+++ b/wsproto/connection.py
@@ -111,8 +111,11 @@ class WSConnection(object):
             b"Connection": b'Upgrade',
             b"Sec-WebSocket-Key": self._nonce,
             b"Sec-WebSocket-Version": self.version,
-            b"Sec-WebSocket-Protocol": ", ".join(self.subprotocols),
         }
+
+        if self.subprotocols:
+            headers[b"Sec-WebSocket-Protocol"] = ", ".join(self.subprotocols)
+
         if self.extensions:
             offers = {e.name: e.offer(self) for e in self.extensions}
             extensions = []


### PR DESCRIPTION
The spec is actually quite clear that it's illegal to send this with
an empty string, and that if the client's list of subprotocol
proposals is empty then it should leave out the Sec-WebSocket-Protocol
header entirely. But I messed it up.