### PR TITLE
rewrite frame_protocol.py using yield from

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ __pycache__
 docs/build
 build
 dist
+
+compliance/reports
+compliance/auto-tests-server-config.json
+compliance/auto-tests-client-config.json
+compliance/autobahntestsuite-venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: python
+sudo: false
 python:
   - "2.7"
   - "3.3"
   - "3.4"
   - "3.5"
   - "pypy-5.3.1"
-sudo: false
+env:
+  - WSACCEL=1
+  - WSACCEL=0
 install:
   - "pip install -U pip setuptools"
   - "pip install ."
@@ -13,6 +16,7 @@ install:
   - "pip install flake8"
   - "pip install sphinx"
   - "pip install codecov"
+  - "if [ $WSACCEL -eq 1 ]; then pip install wsaccel; fi"
 before_script:
   - "flake8 --max-complexity 10 wsproto"
   - "sphinx-build -nW -b html -d docs/build/doctrees docs/source docs/build/html"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 sudo: false
 python:
-  - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
-  - "pypy-5.3.1"
+
 env:
   - WSACCEL=1
   - WSACCEL=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,34 @@ python:
   - "3.5"
 
 env:
-  - WSACCEL=1
-  - WSACCEL=0
-install:
-  - "pip install -U pip setuptools"
-  - "pip install ."
-  - "pip install -r test_requirements.txt"
-  - "pip install flake8"
-  - "pip install sphinx"
-  - "pip install codecov"
-  - "if [ $WSACCEL -eq 1 ]; then pip install wsaccel; fi"
-before_script:
-  - "flake8 --max-complexity 10 wsproto"
-  - "sphinx-build -nW -b html -d docs/build/doctrees docs/source docs/build/html"
+  - MODE=pytest
+    WSACCEL=1
+
+  - MODE=pytest
+    WSACCEL=0
+
+  - MODE=autobahn
+    SIDE=client
+    WSACCEL=1
+
+  - MODE=autobahn
+    SIDE=client
+    WSACCEL=0
+
+  - MODE=autobahn
+    SIDE=server
+    WSACCEL=1
+
+  - MODE=autobahn
+    SIDE=server
+    WSACCEL=0
+
+matrix:
+  include:
+  - python: 3.5
+    env: MODE=docs
+  - python: 3.5
+    env: MODE=flake8
+
 script:
   - "./.travis/run.sh"

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -3,10 +3,53 @@
 set -e
 set -x
 
-mkdir empty
-cd empty
+install_wsproto() {
+    pip install -U pip setuptools
+    python setup.py sdist
+    pip install dist/*
+    if [ $WSACCEL -eq 1 ]; then
+        pip install wsaccel
+    fi
+}
 
-INSTALLDIR=$(python -c "import os, wsproto; print(os.path.dirname(wsproto.__file__))")
-pytest --cov=$INSTALLDIR --cov-config=../.coveragerc ../test/
+case "$MODE" in
+    flake8)
+        pip install flake8
+        flake8 --max-complexity 10 wsproto
+        ;;
 
-codecov
+    docs)
+        # For autodoc
+        install_wsproto
+        pip install sphinx
+        sphinx-build -nW -b html -d docs/build/doctrees docs/source docs/build/html
+        ;;
+    pytest)
+        install_wsproto
+        pip install -r test_requirements.txt
+
+        # Prevent python from seeing our source tree, forcing it to use the
+        # installed version
+        mkdir empty
+        cd empty/
+
+        INSTALLDIR=$(python -c "import os, wsproto; print(os.path.dirname(wsproto.__file__))")
+        pytest --cov=$INSTALLDIR --cov-config=../.coveragerc ../test/
+
+        pip install codecov && codecov
+        ;;
+
+    autobahn)
+        install_wsproto
+        pip install coverage
+
+        cd compliance/
+        python run-autobahn-tests.py --cov --cases=fast "$SIDE"
+
+        pip install codecov && codecov
+        ;;
+
+    *)
+        echo "WTF?"
+        exit 1
+esac

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,9 @@ This needs a pile of cleaning up.
 It passes the autobahn test suite completely and strictly in both client and
 server modes and using permessage-deflate.
 
+If `wsaccel <https://pypi.python.org/pypi/wsaccel>`_ is installed
+(optional), then it will be used to speed things up.
+
 If you want to run the compliance tests, go into the compliance directory and
 then to test client mode, in one shell run the Autobahn test server:
 

--- a/compliance/run-autobahn-tests.py
+++ b/compliance/run-autobahn-tests.py
@@ -1,0 +1,217 @@
+# Things that would be nice:
+# - less hard-coding of paths here
+# - ability to run a specific test case, or set of cases
+# - better reporting of what went wrong on failure
+
+import sys
+import os.path
+import argparse
+import subprocess
+import json
+import socket
+import time
+import copy
+
+PORT = 8642
+
+CLIENT_CONFIG = {
+   "options": {"failByDrop": False},
+   "outdir": "./reports/servers",
+
+   "servers": [
+       {
+           "agent": "wsproto",
+           "url": "ws://localhost:{}".format(PORT),
+           "options": {"version": 18},
+       },
+   ],
+
+   "cases": ["*"],
+   "exclude-cases": [],
+   "exclude-agent-cases": {},
+}
+
+SERVER_CONFIG = {
+   "url": "ws://localhost:{}".format(PORT),
+
+   "options": {"failByDrop": False},
+   "outdir": "./reports/clients",
+   "webport": 8080,
+
+   "cases": ["*"],
+   "exclude-cases": [],
+   "exclude-agent-cases": {}
+}
+
+CASES = {
+    "all": ["*"],
+    "fast":
+        # The core functionality tests
+        ["{}.*".format(i) for i in range(1, 12)]
+        # Compression tests -- in each section, the tests get progressively
+        # slower until they're taking 10s of seconds apiece. And it's
+        # mostly stress tests, without much extra coverage to show for
+        # it. (Weird trick: autobahntestsuite treats these as regexps
+        # except that . is quoted and * becomes .*)
+        + ["12.*.[1234]$", "13.*.[1234]$"]
+        # At one point these were catching a unique bug that none of the
+        # above were -- they're relatively quick and involve
+        # fragmentation.
+        + ["12.1.11", "12.1.12", "13.1.11", "13.1.12"]
+    ,
+}
+
+def say(*args):
+    print("run-tests.py:", *args)
+
+def setup_venv():
+    if not os.path.exists("autobahntestsuite-venv"):
+        say("Creating Python 2.7 environment and installing autobahntestsuite")
+        subprocess.check_call(
+            ["virtualenv", "-p", "python2.7", "autobahntestsuite-venv"])
+        subprocess.check_call(
+            ["autobahntestsuite-venv/bin/pip", "install", "autobahntestsuite"])
+
+def wait_for_listener(port):
+    while True:
+        with socket.socket() as sock:
+            try:
+                sock.connect(("localhost", port))
+            except ConnectionRefusedError:
+                time.sleep(0.01)
+            else:
+                return
+
+def coverage(command, coverage_settings):
+    if not coverage_settings["enabled"]:
+        return [sys.executable] + command
+    else:
+        return ([sys.executable, "-m", "coverage", "run",
+                 "--include", coverage_settings["wsproto-path"],
+                 "--rcfile", coverage_settings["coveragerc"]]
+                + command)
+
+def summarize(index_path):
+    with open(index_path) as f:
+        result_summary = json.load(f)["wsproto"]
+    failed = 0
+    total = 0
+    PASS = {"OK", "INFORMATIONAL"}
+    for test_name, results in sorted(result_summary.items()):
+        total += 1
+        if (results["behavior"] not in PASS
+              or results["behaviorClose"] not in PASS):
+            say("Uh-oh:", test_name, results)
+            failed += 1
+
+    speed_ordered = sorted(result_summary.items(),
+                           key=lambda kv: -kv[1]["duration"])
+    say("Slowest tests:")
+    for test_name, results in speed_ordered[:5]:
+        say("    {}: {} seconds".format(test_name, results["duration"] / 1000))
+
+    return failed, total
+
+def run_client_tests(cases, coverage_settings):
+    say("Starting autobahntestsuite server")
+    server_config = copy.deepcopy(SERVER_CONFIG)
+    server_config["cases"] = cases
+    with open("auto-tests-server-config.json", "w") as f:
+        json.dump(server_config, f)
+    server = subprocess.Popen(
+        ["autobahntestsuite-venv/bin/wstest", "-m", "fuzzingserver",
+         "-s", "auto-tests-server-config.json"])
+    say("Waiting for server to start")
+    wait_for_listener(PORT)
+    try:
+        say("Running wsproto test client")
+        subprocess.check_call(coverage(["./test_client.py"], coverage_settings))
+        # the client doesn't exit until the server closes the connection on the
+        # /updateReports call, and the server doesn't close the connection until
+        # after it writes the reports, so there's no race condition here.
+    finally:
+        say("Stopping server...")
+        server.terminate()
+        server.wait()
+
+    return summarize("reports/clients/index.json")
+
+def run_server_tests(cases, coverage_settings):
+    say("Starting wsproto test server")
+    server = subprocess.Popen(coverage(["./test_server.py"], coverage_settings))
+    try:
+        say("Waiting for server to start")
+        wait_for_listener(PORT)
+
+        client_config = copy.deepcopy(CLIENT_CONFIG)
+        client_config["cases"] = cases
+        with open("auto-tests-client-config.json", "w") as f:
+            json.dump(client_config, f)
+        say("Starting autobahntestsuite client")
+        subprocess.check_call(
+            ["autobahntestsuite-venv/bin/wstest", "-m", "fuzzingclient",
+             "-s", "auto-tests-client-config.json"])
+    finally:
+        say("Stopping server...")
+        # Connection on this port triggers a shutdown
+        with socket.socket() as sock:
+            sock.connect(("localhost", PORT + 1))
+        server.wait()
+
+    return summarize("reports/servers/index.json")
+
+def main():
+    if not os.path.exists("test_client.py"):
+        say("Run me from the compliance/ directory")
+        sys.exit(2)
+    coverage_settings = {
+        "coveragerc": "../.coveragerc",
+    }
+    try:
+        import wsproto
+    except ImportError:
+        say("wsproto must be on python path -- set PYTHONPATH or install it")
+        sys.exit(2)
+    else:
+        coverage_settings["wsproto-path"] = os.path.dirname(wsproto.__file__)
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("MODE", help="'client' or 'server'")
+    # can do e.g.
+    #   --cases='["1.*"]'
+    parser.add_argument("--cases",
+                        help="'fast' or 'all' or a JSON list",
+                        default="fast")
+    parser.add_argument("--cov", help="enable coverage", action="store_true")
+
+    args = parser.parse_args()
+
+    coverage_settings["enabled"] = args.cov
+    cases = args.cases
+    if cases in CASES:
+        cases = CASES[cases]
+    else:
+        cases = json.loads(cases)
+
+    setup_venv()
+
+    if args.MODE == "client":
+        failed, total = run_client_tests(cases, coverage_settings)
+    elif args.MODE == "server":
+        failed, total = run_server_tests(cases, coverage_settings)
+    else:
+        say("Unrecognized mode, try 'client' or 'server'")
+        sys.exit(2)
+
+    say("in {} mode: failed {} out of {} total"
+        .format(args.MODE.upper(), failed, total))
+
+    if failed:
+        say("Test failed")
+        sys.exit(1)
+    else:
+        say("SUCCESS!")
+
+if __name__ == "__main__":
+    main()

--- a/compliance/test_server.py
+++ b/compliance/test_server.py
@@ -5,7 +5,12 @@ from wsproto.connection import WSConnection, SERVER, ConnectionRequested, \
 from wsproto.events import DataReceived
 from wsproto.extensions import PerMessageDeflate
 
+count = 0
+
 def new_conn(reader, writer):
+    global count
+    print("test_server.py received connection {}".format(count))
+    count += 1
     ws = WSConnection(SERVER, extensions=[PerMessageDeflate()])
     closed = False
     while not closed:
@@ -23,26 +28,30 @@ def new_conn(reader, writer):
                 ws.send_data(event.data, event.message_finished)
             elif isinstance(event, ConnectionClosed):
                 closed = True
-            if data is None:
-                break
 
-            try:
-                data = ws.bytes_to_send()
-                writer.write(data)
-                yield from writer.drain()
-            except (ConnectionError, OSError):
-                closed = True
+        if not data:
+            closed = True
 
-            if closed:
-                break
+        try:
+            data = ws.bytes_to_send()
+            writer.write(data)
+            yield from writer.drain()
+        except (ConnectionError, OSError):
+            closed = True
 
     writer.close()
 
+# It's important to get a clean shutdown so that coverage will work
+def shutdown_conn(reader, writer):
+    asyncio.get_event_loop().stop()
+
 start_server = asyncio.start_server(new_conn, '127.0.0.1', 8642)
+start_shutdown_watcher = asyncio.start_server(shutdown_conn, '127.0.0.1', 8643)
 
 if __name__ == '__main__':
     try:
         asyncio.get_event_loop().run_until_complete(start_server)
+        asyncio.get_event_loop().run_until_complete(start_shutdown_watcher)
         asyncio.get_event_loop().run_forever()
     except KeyboardInterrupt:
         pass

--- a/compliance/test_server.py
+++ b/compliance/test_server.py
@@ -20,7 +20,7 @@ def new_conn(reader, writer):
             if isinstance(event, ConnectionRequested):
                 ws.accept(event)
             elif isinstance(event, DataReceived):
-                ws.send_data(event.data, event.final)
+                ws.send_data(event.data, event.message_finished)
             elif isinstance(event, ConnectionClosed):
                 closed = True
             if data is None:

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,8 @@ setup(
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
@@ -55,8 +54,4 @@ setup(
     install_requires=[
         'h11 ~= 0.7.0',  # means: 0.7.x where x >= 0
     ],
-    extras_require={
-        ':python_version == "2.7" or python_version == "3.3"':
-            ['enum34>=1.0.4, <2'],
-    }
 )

--- a/test/test_frame_protocol.py
+++ b/test/test_frame_protocol.py
@@ -1,0 +1,18 @@
+import pytest
+from binascii import unhexlify
+import wsproto.frame_protocol as fp
+
+def test_close_with_long_reason():
+    # Long close reasons get silently truncated
+    proto = fp.FrameProtocol(client=False, extensions=[])
+    data = proto.close(code=fp.CloseReason.NORMAL_CLOSURE,
+                       reason="x" * 200)
+    assert data == unhexlify("887d03e8") + b"x" * 123
+
+    # While preserving valid utf-8
+    proto = fp.FrameProtocol(client=False, extensions=[])
+    # pound sign is 2 bytes in utf-8, so naive truncation to 123 bytes will
+    # cut it in half. Instead we truncate to 122 bytes.
+    data = proto.close(code=fp.CloseReason.NORMAL_CLOSURE,
+                       reason="£" * 100)
+    assert data == unhexlify("887c03e8") + "£".encode("utf-8") * 61

--- a/test/test_frame_protocol.py
+++ b/test/test_frame_protocol.py
@@ -1,5 +1,6 @@
 import pytest
 from binascii import unhexlify
+import struct
 import wsproto.frame_protocol as fp
 
 def test_close_with_long_reason():
@@ -16,3 +17,51 @@ def test_close_with_long_reason():
     data = proto.close(code=fp.CloseReason.NORMAL_CLOSURE,
                        reason="£" * 100)
     assert data == unhexlify("887c03e8") + "£".encode("utf-8") * 61
+
+
+def test_payload_length_decode():
+    # "the minimal number of bytes MUST be used to encode the length, for
+    # example, the length of a 124-byte-long string can't be encoded as the
+    # sequence 126, 0, 124" -- RFC 6455
+
+    def make_header(encoding_bytes, payload_len):
+        if encoding_bytes == 1:
+            assert payload_len <= 125
+            return unhexlify("81") + bytes([payload_len])
+        elif encoding_bytes == 2:
+            assert payload_len < 2**16
+            return unhexlify("81" "7e") + struct.pack("!H", payload_len)
+        elif encoding_bytes == 8:
+            return unhexlify("81" "7f") + struct.pack("!Q", payload_len)
+        else:
+            assert False
+
+    def make_and_parse(encoding_bytes, payload_len):
+        proto = fp.FrameProtocol(client=True, extensions=[])
+        proto.receive_bytes(make_header(encoding_bytes, payload_len))
+        list(proto.received_frames())
+
+    # Valid lengths for 1 byte
+    for payload_len in [0, 1, 2, 123, 124, 125]:
+        make_and_parse(1, payload_len)
+        for encoding_bytes in [2, 8]:
+            with pytest.raises(fp.ParseFailed) as excinfo:
+                make_and_parse(encoding_bytes, payload_len)
+            assert "used {} bytes".format(encoding_bytes) in str(excinfo.value)
+
+    # Valid lengths for 2 bytes
+    for payload_len in [126, 127, 1000, 2**16 - 1]:
+        make_and_parse(2, payload_len)
+        with pytest.raises(fp.ParseFailed) as excinfo:
+            make_and_parse(8, payload_len)
+        assert "used 8 bytes" in str(excinfo.value)
+
+    # Valid lengths for 8 bytes
+    for payload_len in [2**16, 2**16 + 1, 2**32, 2**63 - 1]:
+        make_and_parse(8, payload_len)
+
+    # Invalid lengths for 8 bytes
+    for payload_len in [2**63, 2**63 + 1]:
+        with pytest.raises(fp.ParseFailed) as excinfo:
+            make_and_parse(8, payload_len)
+        assert "non-zero MSB" in str(excinfo.value)

--- a/wsproto/connection.py
+++ b/wsproto/connection.py
@@ -118,12 +118,12 @@ class WSConnection(object):
             offers = {e.name: e.offer(self) for e in self.extensions}
             extensions = []
             for name, params in offers.items():
-                name = name.encode('ascii')
                 if params is True:
-                    extensions.append(name)
+                    extensions.append(name.encode('ascii'))
                 elif params:
-                    params = params.encode('ascii')
-                    extensions.append(b'%s; %s' % (name, params))
+                    # py34 annoyance: doesn't support bytestring formatting
+                    extensions.append(('%s; %s' % (name, params))
+                                      .encode("ascii"))
             if extensions:
                 headers[b'Sec-WebSocket-Extensions'] = b', '.join(extensions)
 
@@ -358,11 +358,12 @@ class WSConnection(object):
         if accepts:
             extensions = []
             for name, params in accepts.items():
-                name = name.encode('ascii')
                 if params is True:
-                    extensions.append(name)
+                    extensions.append(name.encode('ascii'))
                 else:
-                    extensions.append(b'%s; %s' % (name, params))
+                    # py34 annoyance: doesn't support bytestring formatting
+                    extensions.append(('%s; %s' % (name, params.decode("ascii")))
+                                      .encode("ascii"))
             headers[b"Sec-WebSocket-Extensions"] = b', '.join(extensions)
 
         response = h11.InformationalResponse(status_code=101,

--- a/wsproto/connection.py
+++ b/wsproto/connection.py
@@ -362,7 +362,8 @@ class WSConnection(object):
                     extensions.append(name.encode('ascii'))
                 else:
                     # py34 annoyance: doesn't support bytestring formatting
-                    extensions.append(('%s; %s' % (name, params.decode("ascii")))
+                    params = params.decode("ascii")
+                    extensions.append(('%s; %s' % (name, params))
                                       .encode("ascii"))
             headers[b"Sec-WebSocket-Extensions"] = b', '.join(extensions)
 

--- a/wsproto/events.py
+++ b/wsproto/events.py
@@ -52,9 +52,14 @@ class ConnectionFailed(ConnectionClosed):
 
 
 class DataReceived(object):
-    def __init__(self, data, final):
+    def __init__(self, data, frame_finished, message_finished):
         self.data = data
-        self.final = final
+        # This has no semantic content, but is provided just in case some
+        # weird edge case user wants to be able to reconstruct the
+        # fragmentation pattern of the original stream. You don't want it:
+        self.frame_finished = frame_finished
+        # This is the field that you almost certainly want:
+        self.message_finished = message_finished
 
 
 class TextReceived(DataReceived):

--- a/wsproto/frame_protocol.py
+++ b/wsproto/frame_protocol.py
@@ -69,6 +69,7 @@ class CloseReason(IntEnum):
     TRY_AGAIN_LATER = 1013
     TLS_HANDSHAKE_FAILED = 1015
 
+
 # RFC 6455, Section 7.4.1 - Defined Status Codes
 LOCAL_ONLY_CLOSE_REASONS = (
     CloseReason.NO_STATUS_RCVD,

--- a/wsproto/frame_protocol.py
+++ b/wsproto/frame_protocol.py
@@ -82,7 +82,7 @@ NULL_MASK = struct.pack("!I", 0)
 
 class ParseFailed(Exception):
     def __init__(self, msg, code=CloseReason.PROTOCOL_ERROR):
-        super().__init__(self, msg)
+        super().__init__(msg)
         self.code = code
 
 


### PR DESCRIPTION
This isn't complete -- it definitely doesn't pass the autobahn test suite
yet. But I'm posting it to give an idea of what I'm thinking about.

The main thing is to rewrite the frame_protocol.py state machine as linear
code, using 'yield from'. This creates a hard requirement for Python 3.3+.
But given that no-one uses 3.3, and 3.3 is missing enum, and 3.3's
bytearray has quadratic behavior in the way I'm using it, in practice I
think the minimum supported version should be 3.4.

I think the code is much, much clearer. Behaviorally, the main change is
that we know emit partial data frames as we receive them. This is (almost)
invisible to the client (it just looks like peer is sending smaller
fragments -- except that we do expose where the actual fragment boundaries
were in case there are any experts who really want to know this), while
avoiding potential DoS issues and allowing users to get better streaming
behavior.

I believe (but haven't checked) that it should be faster too -- in
particular from removing the str/bytes += loop in add_message_payload.

It also gives better error messages on protocol errors.

It also fixes some technically unrelated bugs I noticed along the way:

- Lots of fragmentation-related bugs in PerMessageDeflate code
- Replace some O(n**2) data structure usage with O(n) equivalents
- Report correct CLOSE codes in more places
- Fix spelling of TLS_HANDSHAKE_FAILED
- Don't echo local-only CLOSE reasons back to the server
- Maybe some others I'm forgetting...
